### PR TITLE
Fix check of sqlite3.

### DIFF
--- a/todo
+++ b/todo
@@ -329,9 +329,8 @@ restore () {
 }
 
 sqlite3checks () {
-    #verify if sqlite3 command is available
-    sqlite3="$(which sqlite3)"
-    which sqlite3 &> /dev/null || unset sqlite3
+    # verify if sqlite3 command is available
+    sqlite3="$(which sqlite3 || true)"
     if [ -z "${sqlite3}" ]
     then
         echo "${0} needs sqlite3 command to run, please install it."


### PR DESCRIPTION
If sqlite3 is not installed, the command "which sqlite3" exits with code 1,
which make todo exit silently.

Therefore no todo command is working and there are no errors displayed.